### PR TITLE
Fix black-on-black targets by using limegreen instead of lime

### DIFF
--- a/src/conf/net/ggtools/grand/Default.properties
+++ b/src/conf/net/ggtools/grand/Default.properties
@@ -14,7 +14,7 @@ dot.weaklink.attributes=fontsize="10",style="dotted"
 dot.subantlink.attributes=fontsize="10",style="dashed"
 
 # Main nodes
-dot.mainnode.attributes=shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold"
+dot.mainnode.attributes=shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold"
 
 # Default nodes
 dot.startnode.attributes=shape=octagon,fillcolor="yellow",style="filled,bold",fontname="Helvetica-Bold"

--- a/src/etc/testcases/build-complex.dot
+++ b/src/etc/testcases/build-complex.dot
@@ -13,7 +13,7 @@ edge [fontsize="10"];
 "check-uptodate-dotfile"
 "check-uptodate-dotfile" -> "prepare-depgraph";
 
-"jar" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="Create jar files for the java classes"];
+"jar" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="Create jar files for the java classes"];
 "jar" -> "compile.java" [label="1"];
 "jar" -> "process-config-files" [label="2"];
 
@@ -37,32 +37,32 @@ edge [fontsize="10"];
 
 "clean.java"
 
-"dist" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="Prepare the distribution"];
+"dist" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="Prepare the distribution"];
 "dist" -> "jar" [label="1"];
 "dist" -> "test" [label="2"];
 
 "check-uptodate-target"
 "check-uptodate-target" -> "prepare-depgraph";
 
-"clean" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="Remove intermediate files"];
+"clean" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="Remove intermediate files"];
 "clean" -> "clean.java" [label="1"];
 "clean" -> "clean.jni" [label="2"];
 "clean" -> "clean.depgraph" [label="3"];
 
-"depgraph" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="Creates a PostScript dependency graph"];
+"depgraph" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="Creates a PostScript dependency graph"];
 "depgraph" -> "check-uptodate-target" [label="1"];
 "depgraph" -> "prepare-depgraph" [label="2"];
 "depgraph" -> "grand" [label="3"];
 
 "init"
 
-"test" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="Run the unit tests"];
+"test" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="Run the unit tests"];
 "test" -> "jar" [label="1"];
 "test" -> "compile" [label="2"];
 
 "process-one-config-file"
 
-"clean.depgraph" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="Remove dependency graph intermediate files."];
+"clean.depgraph" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="Remove dependency graph intermediate files."];
 "clean.depgraph" -> "prepare-depgraph";
 
 "clean.jni"

--- a/src/etc/testcases/build-import.dot
+++ b/src/etc/testcases/build-import.dot
@@ -5,9 +5,9 @@ edge [fontsize="10"];
 "jar" [shape=octagon,fillcolor="yellow",style="filled,bold",fontname="Helvetica-Bold"];
 "jar" -> "grand.jar";
 
-"grand.clean" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
+"grand.clean" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
 
-"javadoc" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
+"javadoc" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
 "javadoc" -> "jar";
 
 "compile-tests"
@@ -15,7 +15,7 @@ edge [fontsize="10"];
 
 "grand.install-maven"
 
-"compile" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
+"compile" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
 "compile" -> "get-deps";
 
 "internal-test"
@@ -24,33 +24,33 @@ edge [fontsize="10"];
 "get-deps"
 "get-deps" -> "init";
 
-"grand.compile" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
+"grand.compile" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
 "grand.compile" -> "get-deps";
 
-"grand.dist" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
+"grand.dist" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
 "grand.dist" -> "jar" [label="1"];
 "grand.dist" -> "javadoc" [label="2"];
 
-"dist" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
+"dist" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
 "dist" -> "jar" [label="1"];
 "dist" -> "javadoc" [label="2"];
 
-"grand.init" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
+"grand.init" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
 
 "grand.get-deps"
 "grand.get-deps" -> "init";
 
-"clean" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
+"clean" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
 
-"grand.test" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
+"grand.test" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
 "grand.test" -> "internal-test";
 
-"init" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
+"init" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
 
 "grand.compile-tests"
 "grand.compile-tests" -> "compile";
 
-"test" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
+"test" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
 "test" -> "internal-test";
 
 "install-maven"
@@ -58,10 +58,10 @@ edge [fontsize="10"];
 "grand.internal-test"
 "grand.internal-test" -> "compile-tests";
 
-"grand.javadoc" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
+"grand.javadoc" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
 "grand.javadoc" -> "jar";
 
-"grand.jar" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Create the jar"];
+"grand.jar" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Create the jar"];
 "grand.jar" -> "compile" [label="1"];
 "grand.jar" -> "test" [label="2"];
 

--- a/src/etc/testcases/build-simple-with-graph-name.dot
+++ b/src/etc/testcases/build-simple-with-graph-name.dot
@@ -11,27 +11,27 @@ edge [fontsize="10"];
 "compile-tests"
 "compile-tests" -> "compile";
 
-"javadoc" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
+"javadoc" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
 "javadoc" -> "jar";
 
-"test" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
+"test" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
 "test" -> "internal-test";
 
-"clean" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
+"clean" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
 
-"dist" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
+"dist" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
 "dist" -> "jar" [label="1"];
 "dist" -> "javadoc" [label="2"];
 
 "get-deps"
 "get-deps" -> "init";
 
-"init" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
+"init" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
 
 "internal-test"
 "internal-test" -> "compile-tests";
 
-"compile" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
+"compile" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
 "compile" -> "get-deps";
 
 }

--- a/src/etc/testcases/build-simple.dot
+++ b/src/etc/testcases/build-simple.dot
@@ -11,27 +11,27 @@ edge [fontsize="10"];
 "compile-tests"
 "compile-tests" -> "compile";
 
-"javadoc" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
+"javadoc" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
 "javadoc" -> "jar";
 
-"test" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
+"test" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
 "test" -> "internal-test";
 
-"clean" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
+"clean" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
 
-"dist" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
+"dist" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
 "dist" -> "jar" [label="1"];
 "dist" -> "javadoc" [label="2"];
 
 "get-deps"
 "get-deps" -> "init";
 
-"init" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
+"init" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
 
 "internal-test"
 "internal-test" -> "compile-tests";
 
-"compile" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
+"compile" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
 "compile" -> "get-deps";
 
 }

--- a/src/etc/testcases/override.dot
+++ b/src/etc/testcases/override.dot
@@ -11,27 +11,27 @@ edge [fontsize="10"];
 "compile-tests"
 "compile-tests" -> "compile";
 
-"javadoc" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
+"javadoc" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Generate javadoc"];
 "javadoc" -> "jar";
 
-"test" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
+"test" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Run the test cases"];
 "test" -> "internal-test";
 
-"clean" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
+"clean" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Clean up the generated directories"];
 
-"dist" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
+"dist" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Create a distribution"];
 "dist" -> "jar" [label="1"];
 "dist" -> "javadoc" [label="2"];
 
 "get-deps"
 "get-deps" -> "init";
 
-"init" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
+"init" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Initializes some properties"];
 
 "internal-test"
 "internal-test" -> "compile-tests";
 
-"compile" [shape=box,fillcolor="lime",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
+"compile" [shape=box,fillcolor="limegreen",style="filled,bold",fontname="Times-Bold",comment="o Compile the code"];
 "compile" -> "get-deps";
 
 }


### PR DESCRIPTION
See #4 - Fixes black-on-black rendered targets & warning about unknown
color using Graphviz dot’s default x11 colorspace.